### PR TITLE
Switch to sapmachine-11-jdk

### DIFF
--- a/src/build/postgres-cf/template/apt.yml
+++ b/src/build/postgres-cf/template/apt.yml
@@ -8,5 +8,5 @@ packages:
   #  - openjdk-8-jre-headless
   #  - openjdk-11-jdk-headless
   #  - openjdk-15-jdk-headless
-  #  - sapmachine-11-jdk
-  - sapmachine-11-jre
+  - sapmachine-11-jdk
+  #  - sapmachine-11-jre

--- a/src/build/postgres-cf/template/deploy.sh
+++ b/src/build/postgres-cf/template/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export JAVA_HOME=/home/vcap/deps/0/apt/opt/sapmachine-11-jre/
+export JAVA_HOME=/home/vcap/deps/0/apt/usr/lib/jvm/sapmachine-11
 export PATH=$PATH:/home/vcap/deps/1/bin
 # Save Certificate from Environment where liquibase expects it
 mkdir -p /home/vcap/.postgresql


### PR DESCRIPTION
Replace sapmachine-11-jre package with sapmachine-11-jdk (no longer provided). 
see #32 and https://github.com/SAP/SapMachine/issues/910