### PR TITLE
remove unused @sap/hana-client dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
       "devDependencies": {
         "@commitlint/cli": "^15.0.0",
         "@commitlint/config-conventional": "^15.0.0",
-        "@sap/hana-client": "^2.10.20",
         "@types/jest": "^27.0.2",
         "@types/yargs": "^17.0.6",
         "cds-pg": "0.1.16",
@@ -1568,33 +1567,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/@sap/hana-client": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.10.20.tgz",
-      "integrity": "sha512-K7Gx+q4B9o+P8yfcd4/QDG3ZKmb8PNWmq8YGMryE4NskNjfrwB7SqbCTda0SP8ne7lajqmuOk1HS1nV5xtQCYA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "hasShrinkwrap": true,
-      "dependencies": {
-        "debug": "3.1.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@sap/hana-client/node_modules/debug": {
-      "version": "3.1.0",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@sap/hana-client/node_modules/ms": {
-      "version": "2.0.0",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
     },
     "node_modules/@sap/xsenv": {
       "version": "3.1.1",
@@ -12361,30 +12333,6 @@
         "yaml": {
           "version": "1.10.2",
           "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
-        }
-      }
-    },
-    "@sap/hana-client": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.10.20.tgz",
-      "integrity": "sha512-K7Gx+q4B9o+P8yfcd4/QDG3ZKmb8PNWmq8YGMryE4NskNjfrwB7SqbCTda0SP8ne7lajqmuOk1HS1nV5xtQCYA==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
-    "@sap/hana-client": "^2.10.20",
     "@types/jest": "^27.0.2",
     "@types/yargs": "^17.0.6",
     "cds-pg": "0.1.16",


### PR DESCRIPTION
@sap/hana-client dependency does not appear to be used anywhere in the project. it's causing an architecural error on `npm install` on m1 processors.