### PR TITLE
add dialect as required by CDS from version 5.1 on

### DIFF
--- a/src/build/postgres-cf/template/package.json
+++ b/src/build/postgres-cf/template/package.json
@@ -15,6 +15,7 @@
         "kind": "database"
       },
       "database": {
+        "dialect": "plain",
         "impl": "cds-pg",
         "model": "csn.json"
       }


### PR DESCRIPTION
Specifying the dialect is required when using the current version of CDS, see also https://github.com/sapmentors/cds-pg#usage-in-your-cap-project.