### PR TITLE
fix: add dialect to cds-pg template package

### DIFF
--- a/src/build/postgres-cf/template/package.json
+++ b/src/build/postgres-cf/template/package.json
@@ -12,7 +12,8 @@
   "cds": {
     "requires": {
       "db": {
-        "kind": "database"
+        "kind": "database",
+        "dialect": "plain"
       },
       "database": {
         "dialect": "plain",


### PR DESCRIPTION
This fix adds the dialect to the template `package.json` file to prevent the issue when deploying with load to Cloud foundry. See https://github.com/mikezaschka/cds-dbm/issues/314